### PR TITLE
Add a simple shell with basic input handling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,4 +10,3 @@ target = "x86_64-blog_os.json"
 
 [target.'cfg(target_os = "none")']
 runner = "bootimage runner"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,14 @@ default-features = false
 features = ["alloc"]
 
 [package.metadata.bootimage]
+# for cargo run
+run-args = ["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04", "-serial", "stdio"]
+
 # 0xf4ポートの4byte
 # -display noneでQEMUを隠すことができる
+# for cargo test
 test-args = ["-device", "isa-debug-exit,iobase=0xf4,iosize=0x04", "-serial", "stdio", "-display", "none"]
 test-success-exit-code = 33  # (0x10 << 1) | 1
-
 
 # should_panicテストをtest_runnerから無効化
 [[test]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,11 +40,13 @@ fn kernel_main(boot_info: &'static BootInfo) -> ! {
 
     allocator::init_heap(&mut mapper, &mut frame_allocator).expect("heap intialization failed");
 
+    #[cfg(test)]
+    test_main();
+
     // execution
     example_mapping(boot_info);
 
     let mut executor = Executor::new();
-    // executor.spawn(Task::new(example_task()));
     executor.spawn(Task::new(keyboard::print_keypress()));
     executor.run();
 }
@@ -114,17 +116,6 @@ fn output_l4_page_table(boot_info: &'static BootInfo) {
                 i,
                 entry.frame().unwrap().start_address()
             );
-            // let phys = entry.frame().unwrap().start_address();
-            // let virt = physical_memory_offset.as_u64() + phys.as_u64();
-            // let ptr = VirtAddr::new(virt).as_mut_ptr();
-            // let l3_table: &PageTable = unsafe { &*ptr };
-
-            // for (i, entry) in l3_table.iter().enumerate() {
-            //     if !entry.is_unused() {
-            //         println!("L3 Entry {}: {:?}", i, entry);
-            //     }
-            //     // println!("L3 Entry {}: {:?}", i, entry);
-            // }
         }
     }
 }
@@ -253,5 +244,5 @@ async fn async_number() -> u32 {
 #[allow(dead_code)]
 async fn example_task() {
     let number = async_number().await;
-    println!("async number: {}", number);
+    println!("async number: {}\n", number);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,6 @@ fn kernel_main(boot_info: &'static BootInfo) -> ! {
     use jura_os::allocator;
     use jura_os::memory::{self, BootInfoFrameAllocator};
 
-    println!("Hello World{}", "!");
-
     // GDT, IDTなどの初期化
     jura_os::init();
 

--- a/src/task/keyboard.rs
+++ b/src/task/keyboard.rs
@@ -16,7 +16,7 @@ static SCANCODE_QUEUE: OnceCell<ArrayQueue<u8>> = OnceCell::uninit();
 static WAKER: AtomicWaker = AtomicWaker::new();
 static PROMPT: &str = "?e235718?jura_os ";
 
-use crate::{print, println};
+use crate::{exit_qemu, print, println, QemuExitCode};
 
 lazy_static! {
     static ref COMMANDS: Mutex<Vec<char>> = Mutex::new(Vec::new());
@@ -106,18 +106,27 @@ fn parse_keypress(key: DecodedKey) {
             }
             'l' => {
                 if *clear_flag {
-                    for _ in 0..24 {
+                    for _ in 0..25 {
                         println!();
                     }
-                    print!("{}", PROMPT);
+                    let msg: String = commands.iter().collect();
+                    print!("{}{}", PROMPT, msg);
+                } else {
+                    commands.push(character);
+                    print!("{}", character);
                 }
                 *clear_flag = false;
-                commands.push(character);
-                print!("{}", character);
+            }
+            'c' => {
+                // qemuを終了
+                if *clear_flag {
+                    exit_qemu(QemuExitCode::Success);
+                }
             }
             _ => {
                 commands.push(character);
                 print!("{}", character);
+                *clear_flag = false;
             }
         },
         DecodedKey::RawKey(key) => match key {

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -58,6 +58,7 @@ struct Buffer {
 }
 
 pub struct Writer {
+    pub row_position: usize,
     column_position: usize,
     color_code: ColorCode,
     buffer: &'static mut Buffer,
@@ -75,7 +76,7 @@ impl Writer {
                     self.new_line();
                 }
 
-                let row = BUFFER_HEIGHT - 1;
+                let row = self.row_position;
                 let col = self.column_position;
 
                 let color_code = self.color_code;
@@ -126,6 +127,26 @@ impl Writer {
             self.buffer.chars[row][col].write(blank);
         }
     }
+
+    #[allow(dead_code)]
+    pub fn clear_word(&mut self) {
+        let blank = ScreenChar {
+            ascii_character: b' ',
+            color_code: self.color_code,
+        };
+
+        if self.column_position == 0 {
+            self.column_position = BUFFER_WIDTH - 1;
+            self.row_position -= 1;
+        } else {
+            self.column_position -= 1;
+        }
+
+        let row = self.row_position;
+        let col = self.column_position;
+
+        self.buffer.chars[row][col].write(blank);
+    }
 }
 
 impl core::fmt::Write for Writer {
@@ -138,6 +159,7 @@ impl core::fmt::Write for Writer {
 lazy_static! {
     // spin::Mutexで内部可変性を追加
     pub static ref WRITER: Mutex<Writer> = Mutex::new(Writer {
+        row_position: BUFFER_HEIGHT - 1,
         column_position: 0,
         color_code: ColorCode::new(Color::Yellow, Color::Black),
         // 0xb8000はVGAテキストモードのバッファが配置されている物理アドレス


### PR DESCRIPTION
## Overview
This PR implements a simple shell that:
- Displays a prompt (`?e235718?jura_os `)
- Collects user input and returns it after pressing Enter
- Clears the screen when `Ctrl + L` is pressed

## Changes
- Implement a basic input handler
- Add a global command buffer
- Separate keyboard input processing into a function

## How to Test
1. Run the OS
2. Type any input and press Enter → It should return your input
3. Press `Ctrl + L` → The screen should clear
